### PR TITLE
Added ability to register component aliases

### DIFF
--- a/src/Blade.php
+++ b/src/Blade.php
@@ -93,6 +93,21 @@ class Blade
 
 
     /**
+     * Register a component alias directive.
+     *
+     * @param string $path Path to blade component e.g. `components.radio-input`.
+     * @param string|null $alias Name of the component alias. If null, alias will be created
+     *                           from last item of exploed path e.g. `radio-input`.
+     *
+     * @return BladeInterface
+     */
+    public function component(string $path, string $alias=null): BladeInterface
+    {
+        return static::getInstance()->component($path, $alias);
+    }
+
+
+    /**
      * Register an custom conditional directive.
      *
      * @param string $name

--- a/src/BladeInstance.php
+++ b/src/BladeInstance.php
@@ -205,6 +205,25 @@ class BladeInstance implements BladeInterface
 
 
     /**
+     * Register a component alias directive.
+     *
+     * @param string $path Path to blade component e.g. `components.radio-input`.
+     * @param string|null $alias Name of the component alias. If null, alias will be created
+     *                           from last item of exploed path e.g. `radio-input`.
+     *
+     * @return BladeInterface
+     */
+    public function component(string $path, string $alias=null): BladeInterface
+    {
+        $this
+            ->getCompiler()
+            ->component($path, $alias);
+
+        return $this;
+    }
+
+
+    /**
      * Register an custom conditional directive.
      *
      * @param string $name


### PR DESCRIPTION
Adds the ability to register component aliases. Docs can be found here: https://laravel.com/docs/5.8/blade#components-and-slots 