### PR TITLE
Improve PHPUnit fixtures and assertions

### DIFF
--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -16,7 +16,7 @@ abstract class AbstractTest extends TestCase
     protected $directives;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->blade = new BladeCompiler(new Filesystem(), "/tmp/phpunit/cache/views");
 

--- a/tests/BladeInstanceTest.php
+++ b/tests/BladeInstanceTest.php
@@ -16,7 +16,7 @@ class BladeInstanceTest extends TestCase
     private $blade;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->blade = new BladeInstance(__DIR__ . "/views", Utils::getCachePath());
     }

--- a/tests/BladeMockTest.php
+++ b/tests/BladeMockTest.php
@@ -24,7 +24,7 @@ class BladeMockTest extends TestCase
     private $factory;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->blade = new BladeInstance(__DIR__ . "/views", Utils::getCachePath());
 

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -15,7 +15,7 @@ use function trim;
 class BladeTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $blade = new BladeInstance(__DIR__ . "/views", Utils::getCachePath());
         Blade::setInstance($blade);

--- a/tests/ConditionHandlerTest.php
+++ b/tests/ConditionHandlerTest.php
@@ -11,7 +11,7 @@ class ConditionHandlerTest extends TestCase
     private $handler;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->handler = new ConditionHandler();
     }
@@ -46,7 +46,7 @@ class ConditionHandlerTest extends TestCase
         });
 
         $result = $this->handler->check("test");
-        $this->assertSame(true, $result);
+        $this->assertTrue($result);
     }
     public function testCheck3(): void
     {

--- a/tests/DirectivesTest.php
+++ b/tests/DirectivesTest.php
@@ -17,7 +17,7 @@ class DirectivesTest extends TestCase
     private $compiler;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->directives = (new Directives())
             ->withoutNamespace()
@@ -29,7 +29,7 @@ class DirectivesTest extends TestCase
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` and `protected function tearDown` methods.
- Using the `assertTrue` to assert expected is `true`.